### PR TITLE
feat: stdlib formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ Add `ncalendar` to your project dependencies.
 | Function | Description |
 | --------  | ------------ |
 | `ncalendar:convert/3` | Converts a binary representation of a datetime in a given format to the specified target format |
-| `ncalendar:from_datetime/2` | Generates a binary representation of the given `calendar:datetime()` value with no UTC offset in the given format |
-| `ncalendar:from_datetime/2` | Generates a binary representation of the given `calendar:datetime()` value in the given timezone and format |
+| `ncalendar:from_datetime/2` | Generates a binary representation of the given `calendar:datetime()` value in the given format |
+| `ncalendar:from_gregorian_seconds/2` | Generates a binary representation of the given number of gregorian seconds in the given format |
+| `ncalendar:from_timestamp/2` | Generates a binary representation of the given `erlang:timestamp()` value in the given format |
 | `ncalendar:is_valid/2` | Checks the validity of a binary representation of a datetime with respect to the specified format |
 | `ncalendar:now/1` | Generates a binary representation of the current datetime with no UTC offset in the given format |
 | `ncalendar:now/2` | Generates a binary representation of the current datetime in the given format and timezone |

--- a/README.md
+++ b/README.md
@@ -22,9 +22,12 @@ Add `ncalendar` to your project dependencies.
 | Function | Description |
 | --------  | ------------ |
 | `ncalendar:convert/3` | Converts a binary representation of a datetime in a given format to the specified target format |
+| `ncalendar:from_datetime/2` | Generates a binary representation of the given `calendar:datetime()` value with no UTC offset in the given format |
+| `ncalendar:from_datetime/2` | Generates a binary representation of the given `calendar:datetime()` value in the given timezone and format |
 | `ncalendar:is_valid/2` | Checks the validity of a binary representation of a datetime with respect to the specified format |
 | `ncalendar:now/1` | Generates a binary representation of the current datetime with no UTC offset in the given format |
 | `ncalendar:now/2` | Generates a binary representation of the current datetime in the given format and timezone |
+| `ncalendar:to_datetime/2` | Converts a binary representation of a datetime in the given format to a `calendar:datetime()` value |
 
 ## Supported formats
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Add `ncalendar` to your project dependencies.
 | `ncalendar:now/1` | Generates a binary representation of the current datetime with no UTC offset in the given format |
 | `ncalendar:now/2` | Generates a binary representation of the current datetime in the given format and timezone |
 | `ncalendar:to_datetime/2` | Converts a binary representation of a datetime in the given format to a `calendar:datetime()` value |
+| `ncalendar:to_gregorian_seconds/2` | Converts a binary representation of a datetime in the given format to the integer value of gregorian seconds |
+| `ncalendar:to_timestamp/2` | Converts a binary representation of a datetime in the given format to a `erlang:timestamp()` value |
 
 ## Supported formats
 

--- a/src/ncalendar.erl
+++ b/src/ncalendar.erl
@@ -34,6 +34,8 @@
 -export_type([
     datetime/0,
     format/0,
+    gregorian_seconds/0,
+    timestamp/0,
     timezone/0,
     timezone_alias/0,
     value/0

--- a/src/ncalendar.erl
+++ b/src/ncalendar.erl
@@ -19,9 +19,21 @@
 %%% EXTERNAL EXPORTS
 -export([
     convert/3,
+    from_datetime/2,
+    from_datetime/3,
     is_valid/2,
     now/1,
-    now/2
+    now/2,
+    to_datetime/2
+]).
+
+%%% TYPES
+-export_type([
+    datetime/0,
+    format/0,
+    timezone/0,
+    timezone_alias/0,
+    value/0
 ]).
 
 %%%-----------------------------------------------------------------------------
@@ -30,16 +42,32 @@
 -spec convert(From, To, Value) -> Result when
     From :: format(),
     To :: format(),
-    Value :: binary(),
-    Result :: binary().
+    Value :: value(),
+    Result :: value().
 convert(From, To, Value) ->
     ModFrom = mod(From),
     ModTo = mod(To),
-    ModTo:from_datetime(ModFrom:to_datetime(Value)).
+    ModTo:from_datetimezone(ModFrom:to_datetimezone(Value)).
+
+-spec from_datetime(Format, Datetime) -> Result when
+    Format :: format(),
+    Datetime :: datetime(),
+    Result :: value().
+from_datetime(Format, Datetime) ->
+    from_datetime(Format, Datetime, +0000).
+
+-spec from_datetime(Format, Datetime, Timezone) -> Result when
+    Format :: format(),
+    Datetime :: datetime(),
+    Timezone :: timezone(),
+    Result :: value().
+from_datetime(Format, Datetime, Timezone) ->
+    Mod = mod(Format),
+    Mod:from_datetimezone({Datetime, Timezone}).
 
 -spec is_valid(Format, Value) -> Result when
     Format :: format(),
-    Value :: binary(),
+    Value :: value(),
     Result :: boolean().
 is_valid(Format, Value) ->
     Mod = mod(Format),
@@ -58,7 +86,16 @@ now(Format) ->
 now(Format, Timezone) ->
     {Date, Time} = erlang:universaltime(),
     Mod = mod(Format),
-    Mod:from_datetime({Date, Time, Timezone}).
+    Mod:from_datetimezone({{Date, Time}, Timezone}).
+
+-spec to_datetime(Format, Value) -> Result when
+    Format :: format(),
+    Value :: value(),
+    Result :: datetime().
+to_datetime(Format, Value) ->
+    Mod = mod(Format),
+    Datetimezone = Mod:to_datetimezone(Value),
+    ncalendar_util:datetimezone_to_datetime(Datetimezone).
 
 %%%-----------------------------------------------------------------------------
 %%% INTERNAL FUNCTIONS

--- a/src/ncalendar.erl
+++ b/src/ncalendar.erl
@@ -20,11 +20,14 @@
 -export([
     convert/3,
     from_datetime/2,
-    from_datetime/3,
+    from_gregorian_seconds/2,
+    from_timestamp/2,
     is_valid/2,
     now/1,
     now/2,
-    to_datetime/2
+    to_datetime/2,
+    to_gregorian_seconds/2,
+    to_timestamp/2
 ]).
 
 %%% TYPES
@@ -35,6 +38,9 @@
     timezone_alias/0,
     value/0
 ]).
+
+%%% MACROS
+-define(JANUARY_1ST_1970, 62167219200).
 
 %%%-----------------------------------------------------------------------------
 %%% EXTERNAL EXPORTS
@@ -54,16 +60,24 @@ convert(From, To, Value) ->
     Datetime :: datetime(),
     Result :: value().
 from_datetime(Format, Datetime) ->
-    from_datetime(Format, Datetime, +0000).
-
--spec from_datetime(Format, Datetime, Timezone) -> Result when
-    Format :: format(),
-    Datetime :: datetime(),
-    Timezone :: timezone(),
-    Result :: value().
-from_datetime(Format, Datetime, Timezone) ->
     Mod = mod(Format),
-    Mod:from_datetimezone({Datetime, Timezone}).
+    Mod:from_datetimezone({Datetime, +0000}).
+
+-spec from_gregorian_seconds(Format, GregorianSeconds) -> Result when
+    Format :: format(),
+    GregorianSeconds :: gregorian_seconds(),
+    Result :: value().
+from_gregorian_seconds(Format, GregorianSeconds) ->
+    Datetime = calendar:gregorian_seconds_to_datetime(GregorianSeconds),
+    from_datetime(Format, Datetime).
+
+-spec from_timestamp(Format, Timestamp) -> Result when
+    Format :: format(),
+    Timestamp :: timestamp(),
+    Result :: value().
+from_timestamp(Format, {MSecs, Secs, _MicroSecs}) ->
+    GregorianSeconds = MSecs * 1000000 + Secs + ?JANUARY_1ST_1970,
+    from_gregorian_seconds(Format, GregorianSeconds).
 
 -spec is_valid(Format, Value) -> Result when
     Format :: format(),
@@ -96,6 +110,23 @@ to_datetime(Format, Value) ->
     Mod = mod(Format),
     Datetimezone = Mod:to_datetimezone(Value),
     ncalendar_util:datetimezone_to_datetime(Datetimezone).
+
+-spec to_gregorian_seconds(Format, Value) -> Result when
+    Format :: format(),
+    Value :: value(),
+    Result :: gregorian_seconds().
+to_gregorian_seconds(Format, Value) ->
+    Datetime = to_datetime(Format, Value),
+    calendar:datetime_to_gregorian_seconds(Datetime).
+
+-spec to_timestamp(Format, Value) -> Result when
+    Format :: format(),
+    Value :: value(),
+    Result :: timestamp().
+to_timestamp(Format, Value) ->
+    GregorianSeconds = to_gregorian_seconds(Format, Value),
+    Secs = GregorianSeconds - ?JANUARY_1ST_1970,
+    {Secs div 1000000, Secs rem 1000000, 0}.
 
 %%%-----------------------------------------------------------------------------
 %%% INTERNAL FUNCTIONS

--- a/src/ncalendar.hrl
+++ b/src/ncalendar.hrl
@@ -15,10 +15,11 @@
 -define(ncalendar, true).
 
 %%% TYPES
--type datetime() :: {date(), time(), timezone() | timezone_alias()}.
--type format() :: iso8601.
 -type date() :: calendar:date().
--type time() :: calendat:time().
+-type datetime() :: calendar:datetime().
+-type datetimezone() :: {datetime(), timezone() | timezone_alias()}.
+-type format() :: iso8601.
+-type time() :: calendar:time().
 -type timezone() ::
     -1200
     | -1100

--- a/src/ncalendar.hrl
+++ b/src/ncalendar.hrl
@@ -19,7 +19,9 @@
 -type datetime() :: calendar:datetime().
 -type datetimezone() :: {datetime(), timezone() | timezone_alias()}.
 -type format() :: iso8601.
+-type gregorian_seconds() :: non_neg_integer().
 -type time() :: calendar:time().
+-type timestamp() :: erlang:timestamp().
 -type timezone() ::
     -1200
     | -1100

--- a/src/ncalendar_format.erl
+++ b/src/ncalendar_format.erl
@@ -19,14 +19,14 @@
 %%%-----------------------------------------------------------------------------
 %%% BEHAVIOUR CALLBACKS
 %%%-----------------------------------------------------------------------------
--callback from_datetime(Datetime) -> Result when
-    Datetime :: datetime(),
+-callback from_datetimezone(Datetimezone) -> Result when
+    Datetimezone :: datetimezone(),
     Result :: value().
 
 -callback is_valid(Value) -> Result when
     Value :: value(),
     Result :: boolean().
 
--callback to_datetime(Value) -> Result when
+-callback to_datetimezone(Value) -> Result when
     Value :: value(),
-    Result :: datetime().
+    Result :: datetimezone().

--- a/test/ncalendar_SUITE.erl
+++ b/test/ncalendar_SUITE.erl
@@ -21,7 +21,8 @@
 %%%-----------------------------------------------------------------------------
 all() ->
     [
-        {group, properties}
+        {group, properties},
+        datetime
     ].
 
 groups() ->
@@ -68,3 +69,9 @@ there_and_back_again(Conf) ->
         ncalendar_properties:prop_there_and_back_again(),
         Conf
     ).
+
+datetime(_Conf) ->
+    Timestamp = erlang:timestamp(),
+    Datetime = calendar:now_to_datetime(Timestamp),
+    Bin = ncalendar:from_datetime(iso8601, Datetime),
+    Datetime = ncalendar:to_datetime(iso8601, Bin).

--- a/test/ncalendar_SUITE.erl
+++ b/test/ncalendar_SUITE.erl
@@ -22,7 +22,9 @@
 all() ->
     [
         {group, properties},
-        datetime
+        datetime,
+        gregorian_seconds,
+        timestamp
     ].
 
 groups() ->
@@ -71,7 +73,18 @@ there_and_back_again(Conf) ->
     ).
 
 datetime(_Conf) ->
-    Timestamp = erlang:timestamp(),
-    Datetime = calendar:now_to_datetime(Timestamp),
+    Datetime = calendar:universal_time(),
     Bin = ncalendar:from_datetime(iso8601, Datetime),
     Datetime = ncalendar:to_datetime(iso8601, Bin).
+
+gregorian_seconds(_Conf) ->
+    Datetime = calendar:universal_time(),
+    GregorianSeconds = calendar:datetime_to_gregorian_seconds(Datetime),
+    Bin = ncalendar:from_gregorian_seconds(iso8601, GregorianSeconds),
+    GregorianSeconds = ncalendar:to_gregorian_seconds(iso8601, Bin).
+
+timestamp(_Conf) ->
+    Timestamp = erlang:timestamp(),
+    Bin = ncalendar:from_timestamp(iso8601, Timestamp),
+    {MSecs, Secs, _MicroSecs1} = Timestamp,
+    {MSecs, Secs, 0} = ncalendar:to_timestamp(iso8601, Bin).


### PR DESCRIPTION
Adds support for `from`/`to` operations using the following `stdlib` formats:
- `calendar:datetime()`
- Gregorian seconds
-  `erlang:timestamp()`